### PR TITLE
use more compact codec protocol for mastNode

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -1,0 +1,150 @@
+package mast
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+func appendLength(buf []byte, n int) []byte {
+	var tmpbuf [8]byte
+	len := binary.PutUvarint(tmpbuf[:], uint64(n))
+	return append(buf, tmpbuf[:len]...)
+}
+
+func appendEfaceSlice(buf []byte, l []interface{}, marshal func(interface{}) ([]byte, error)) ([]byte, error) {
+	buf = appendLength(buf, len(l))
+	for _, elem := range l {
+		body, err := marshal(elem)
+		if err != nil {
+			return nil, err
+		}
+		buf = appendLength(buf, len(body))
+		buf = append(buf, body...)
+	}
+	return buf, nil
+}
+
+func decodeLength(buf []byte, n *int) ([]byte, error) {
+	k, len := binary.Uvarint(buf)
+	if len <= 0 {
+		return nil, errors.New("bad length")
+	}
+	*n = int(k)
+	return buf[len:], nil
+}
+
+func decodeBytes(buf []byte, body *[]byte) ([]byte, error) {
+	var err error
+	var n int
+	buf, err = decodeLength(buf, &n)
+	if err != nil {
+		return nil, err
+	}
+	if n == 0 {
+		return buf, nil
+	}
+	if len(buf) < n {
+		return nil, errors.New("bad body length")
+	}
+	*body = buf[:n]
+	return buf[n:], nil
+}
+
+func decodeEfaceSlice(buf []byte, l *[]interface{}, elemT reflect.Type, unmarshal func([]byte, interface{}) error) ([]byte, error) {
+	var err error
+	var total int
+	buf, err = decodeLength(buf, &total)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]interface{}, total)
+	for i := 0; i < total; i++ {
+		var body []byte
+		buf, err = decodeBytes(buf, &body)
+		if err != nil {
+			return nil, err
+		}
+		if body != nil && elemT != nil {
+			elem := reflect.New(elemT)
+			err = unmarshal(body, elem.Interface())
+			if err != nil {
+				return nil, err
+			}
+			out[i] = elem.Elem().Interface()
+		}
+	}
+	*l = out
+	return buf, nil
+}
+
+func decodeStringSlice(buf []byte, l *[]interface{}) ([]byte, error) {
+	var err error
+	var total int
+	buf, err = decodeLength(buf, &total)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]interface{}, total)
+	for i := 0; i < total; i++ {
+		var body []byte
+		buf, err = decodeBytes(buf, &body)
+		if err != nil {
+			return nil, err
+		}
+		if body != nil {
+			out[i] = string(body)
+		}
+	}
+	*l = out
+	return buf, nil
+
+}
+
+func marshalMastNode(node *mastNode, marshal func(interface{}) ([]byte, error)) ([]byte, error) {
+	var buf []byte
+	var err error
+	buf, err = appendEfaceSlice(buf, node.Key, marshal)
+	if err != nil {
+		return nil, err
+	}
+	buf, err = appendEfaceSlice(buf, node.Value, marshal)
+	if err != nil {
+		return nil, err
+	}
+
+	buf = appendLength(buf, len(node.Link))
+	for _, link := range node.Link {
+		var str string
+		if link != nil {
+			var ok bool
+			str, ok = link.(string)
+			if !ok {
+				panic(fmt.Sprintf("expect string link when marshalNode, got:%T", link))
+			}
+		}
+		buf = appendLength(buf, len(str))
+		buf = append(buf, str...)
+	}
+	return buf, nil
+}
+
+func unmarshalMastNode(m *Mast, buf []byte, node *mastNode) error {
+	var err error
+	keyT := reflect.TypeOf(m.zeroKey)
+	buf, err = decodeEfaceSlice(buf, &node.Key, keyT, m.unmarshal)
+	if err != nil {
+		return fmt.Errorf("error when unmarshal node.Key:%s", err)
+	}
+	valueT := reflect.TypeOf(m.zeroValue)
+	buf, err = decodeEfaceSlice(buf, &node.Value, valueT, m.unmarshal)
+	if err != nil {
+		return fmt.Errorf("error when unmarshal node.Value:%s", err)
+	}
+	buf, err = decodeStringSlice(buf, &node.Link)
+	if err != nil {
+		return fmt.Errorf("error when unmarshal node.Link:%s", err)
+	}
+	return nil
+}

--- a/store.go
+++ b/store.go
@@ -61,66 +61,7 @@ func (m *Mast) loadPersisted(ctx context.Context, l string) (*mastNode, error) {
 }
 
 func unmarshalNode(m *Mast, nodeBytes []byte, l string, node *mastNode) error {
-	if m.unmarshalerUsesRegisteredTypes {
-		return unmarshalNodeWithRegisteredTypes(m, nodeBytes, l, node)
-	}
-	return unmarshalStringNode(m, nodeBytes, l, node)
-}
-
-func unmarshalStringNode(m *Mast, nodeBytes []byte, l string, node *mastNode) error {
-	var stringNode stringNodeT
-	err := m.unmarshal(nodeBytes, &stringNode)
-	if err != nil {
-		return fmt.Errorf("unmarshaling %s: %w", l, err)
-	}
-	if len(stringNode.Key) != len(stringNode.Value) {
-		return fmt.Errorf("cannot unmarshal %s: mismatched keys and values", l)
-	}
-	*node = mastNode{
-		make([]interface{}, len(stringNode.Key)),
-		make([]interface{}, len(stringNode.Value)),
-		make([]interface{}, len(stringNode.Key)+1),
-		false, true, nil, &l,
-	}
-	for i := 0; i < len(stringNode.Key); i++ {
-		aType := reflect.TypeOf(m.zeroKey)
-		aCopy := reflect.New(aType)
-		err = m.unmarshal(stringNode.Key[i], aCopy.Interface())
-		if err != nil {
-			return fmt.Errorf("cannot unmarshal key[%d] in %s: %w", i, l, err)
-		}
-		newKey := aCopy.Elem().Interface()
-
-		var newValue interface{}
-		if m.zeroValue != nil {
-			aType = reflect.TypeOf(m.zeroValue)
-			aCopy = reflect.New(aType)
-			err = m.unmarshal(stringNode.Value[i], aCopy.Interface())
-			if err != nil {
-				return fmt.Errorf("cannot unmarshal value[%d] in %s: %w", i, l, err)
-			}
-			newValue = aCopy.Elem().Interface()
-		} else {
-			newValue = nil
-		}
-		node.Key[i] = newKey
-		node.Value[i] = newValue
-	}
-	if stringNode.Link != nil {
-		for i, l := range stringNode.Link {
-			if l == "" {
-				node.Link[i] = nil
-			} else {
-				node.Link[i] = l
-			}
-		}
-	}
-	node.expected = node.xcopy()
-	return nil
-}
-
-func unmarshalNodeWithRegisteredTypes(m *Mast, nodeBytes []byte, l string, node *mastNode) error {
-	err := m.unmarshal(nodeBytes, &node)
+	err := unmarshalMastNode(m, nodeBytes, node)
 	if err != nil {
 		return fmt.Errorf("unmarshal: %w", err)
 	}
@@ -200,7 +141,7 @@ func (node *mastNode) store(
 	if linkCount == 0 {
 		trimmed.Link = nil
 	}
-	encoded, err := marshal(trimmed)
+	encoded, err := marshalMastNode(&trimmed, marshal)
 	if err != nil {
 		return "", fmt.Errorf("marshal: %w", err)
 	}


### PR DESCRIPTION
A `length + content` encoding scheme is used to encode and decode `mastNode`.

update #78 